### PR TITLE
Add `elm_make_path` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ Or install it yourself as:
 
 ## Usage
 
-> NOTE: Make sure [Elm](http://elm-lang.org/install) is installed. If the `elm-make` executable can't be found in the current `PATH`, the exception `Elm::Compiler::ExecutableNotFound` will be thrown.
+> NOTE: Make sure [Elm](http://elm-lang.org/install) is installed. If the `elm-make` executable can't be found in the current `PATH` or via the `elm_make_path` option, the exception `Elm::Compiler::ExecutableNotFound` will be thrown.
 
 ```ruby
-Elm::Compiler.compile(elm_files, output_path = nil)
+Elm::Compiler.compile(elm_files, output_path: nil, elm_make_path: nil)
 ```
 
 * `elm_files`: Accepts a single file path or an array of file paths.
 * `output_path`: Path to the output file. If left blank, the compiled Javascript will be returned as a string.
+* `elm_make_path`: Path to the `elm-make` executable. If left blank, the executable will be looked up in the current `PATH`.
 
 
 
@@ -56,13 +57,13 @@ Elm::Compiler.compile(["Clock.elm", "Counter.elm"])
 Compile to file:
 
 ```ruby
-Elm::Compiler.compile("Clock.elm", "elm.js")
+Elm::Compiler.compile("Clock.elm", output_path: "elm.js")
 ```
 
 Compile multiple files to file:
 
 ```ruby
-Elm::Compiler.compile(["Clock.elm", "Counter.elm"], "elm.js")
+Elm::Compiler.compile(["Clock.elm", "Counter.elm"], output_path: "elm.js")
 ```
 
 ## Contributing

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -9,12 +9,13 @@ module Elm
       new(*args).compile
     end
 
-    def initialize(elm_files, output_path = nil)
+    def initialize(elm_files, output_path = nil, elm_path = nil)
       @elm_files = elm_files
       @output_path = output_path
+      @elm_path = elm_path
     end
 
-    attr_reader :elm_files, :output_path
+    attr_reader :elm_files, :output_path, :elm_path
 
     def compile
       fail ExecutableNotFound unless elm_executable_exists?
@@ -29,7 +30,7 @@ module Elm
     private
 
     def elm_executable_exists?
-      !find_executable0('elm-make').nil?
+      File.exist?(elm_executable)
     end
 
     def compile_to_string(elm_files)
@@ -44,8 +45,16 @@ module Elm
     end
 
     def elm_make(elm_files, output_path)
-      Open3.popen3('elm-make', *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+      Open3.popen3(elm_executable, *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
         fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
+      end
+    end
+
+    def elm_executable
+      if elm_path
+        elm_path
+      else
+        find_executable0('elm-make')
       end
     end
   end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -5,38 +5,47 @@ require 'mkmf'
 
 module Elm
   class Compiler
-    class << self
-      def compile(elm_files, output_path = nil)
-        fail ExecutableNotFound unless elm_executable_exists?
+    def self.compile(*args)
+      new(*args).compile
+    end
 
-        if output_path
-          elm_make(elm_files, output_path)
-        else
-          compile_to_string(elm_files)
-        end
+    def initialize(elm_files, output_path = nil)
+      @elm_files = elm_files
+      @output_path = output_path
+    end
+
+    attr_reader :elm_files, :output_path
+
+    def compile
+      fail ExecutableNotFound unless elm_executable_exists?
+
+      if output_path
+        elm_make(elm_files, output_path)
+      else
+        compile_to_string(elm_files)
+      end
+    end
+
+    private
+
+    def elm_executable_exists?
+      !find_executable0('elm-make').nil?
+    end
+
+    def compile_to_string(elm_files)
+      output = ''
+
+      Tempfile.open(['elm', '.js']) do |tempfile|
+        elm_make(elm_files, tempfile.path)
+        output = File.read tempfile.path
       end
 
-      private
+      output
+    end
 
-      def elm_executable_exists?
-        !find_executable0('elm-make').nil?
-      end
-
-      def compile_to_string(elm_files)
-        output = ''
-
-        Tempfile.open(['elm', '.js']) do |tempfile|
-          elm_make(elm_files, tempfile.path)
-          output = File.read tempfile.path
-        end
-
-        output
-      end
-
-      def elm_make(elm_files, output_path)
-        Open3.popen3('elm-make', *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
-          fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
-        end
+    def elm_make(elm_files, output_path)
+      Open3.popen3('elm-make', *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+        fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
       end
     end
   end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -41,7 +41,8 @@ module Elm
     end
 
     def to_file(path = output_path)
-      Open3.popen3(elm_executable, *elm_files, '--yes', '--output', path) do |_stdin, _stdout, stderr, wait_thr|
+      # set locale to utf8 as a workaround until https://github.com/elm-lang/elm-make/pull/83 is merged and released
+      Open3.popen3({"LANG" => "en_US.UTF8" }, elm_executable, *elm_files, '--yes', '--output', path) do |_stdin, _stdout, stderr, wait_thr|
         fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
       end
     end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -1,7 +1,6 @@
 require 'elm/compiler/exceptions'
 require 'open3'
 require 'tempfile'
-require 'mkmf'
 
 module Elm
   class Compiler
@@ -48,7 +47,7 @@ module Elm
     end
 
     def elm_executable
-      elm_make_path || find_executable0('elm-make')
+      elm_make_path || `which elm-make`.chomp
     end
   end
 end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -9,7 +9,7 @@ describe Elm::Compiler do
 
   describe '#compile' do
     it "should raise ExecutableNotFound if Elm isn't installed" do
-      allow(Elm::Compiler).to receive(:elm_executable_exists?).and_return(false)
+      allow_any_instance_of(Elm::Compiler).to receive(:elm_executable_exists?).and_return(false)
       code = proc { Elm::Compiler.compile(test_file) }
       expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
     end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -49,5 +49,16 @@ describe Elm::Compiler do
         expect(File.exist?('elm.js')).to be(true)
       end
     end
+
+    context 'elm_path given' do
+      it 'should raise ExecutableNoFound if path is bad' do
+        code = proc { Elm::Compiler.compile(test_file, nil, "bad/path/to/elm") }
+        expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
+      end
+
+      it 'should work if path is good' do
+        Elm::Compiler.compile(test_file, nil, `which elm`.chomp)
+      end
+    end
   end
 end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -38,26 +38,26 @@ describe Elm::Compiler do
       end
 
       it 'should write to the given output_path' do
-        output = Elm::Compiler.compile(test_file, 'elm.js')
+        output = Elm::Compiler.compile(test_file, output_path: 'elm.js')
         expect(output).to be_nil
         expect(File.exist?('elm.js')).to be(true)
       end
 
       it 'should accept a string or an array of strings' do
-        output = Elm::Compiler.compile([test_file], 'elm.js')
+        output = Elm::Compiler.compile([test_file], output_path: 'elm.js')
         expect(output).to be_nil
         expect(File.exist?('elm.js')).to be(true)
       end
     end
 
-    context 'elm_path given' do
+    context 'elm_make_path given' do
       it 'should raise ExecutableNoFound if path is bad' do
-        code = proc { Elm::Compiler.compile(test_file, nil, "bad/path/to/elm") }
+        code = proc { Elm::Compiler.compile(test_file, elm_make_path: "bad/path/to/elm-make") }
         expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
       end
 
       it 'should work if path is good' do
-        Elm::Compiler.compile(test_file, nil, `which elm`.chomp)
+        Elm::Compiler.compile(test_file, elm_make_path: `which elm-make`.chomp)
       end
     end
   end


### PR DESCRIPTION
At first I tried to make this PR minimally invasive, but I ended up needing to refactor the compiler to an instance to prevent code duplication around which compiler path to use. 

WDYT?

Closes #1.
