### PR TITLE
Custom elm path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@
 /spec/reports/
 /tmp/
 /elm-stuff/
-/elm-package.json
 /elm.js
 *.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ cache: bundler
 rvm:
   - 2.2.3
 sudo: false
-before_install: gem install bundler -v 1.11.2
+before_install:
+  - gem install bundler -v 1.11.2
 install:
   - bundle install
   - npm install elm
+  - rm -r elm-stuff
   - elm-package install --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ before_install:
 install:
   - bundle install
   - npm install elm
-  - rm -r elm-stuff
   - elm-package install --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
   - gem install bundler -v 1.11.2
 install:
   - bundle install
-  - npm install elm
+  - npm install -g elm@0.17
   - elm-package install --yes

--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ Or install it yourself as:
 
 ## Usage
 
-> NOTE: Make sure [Elm](http://elm-lang.org/install) is installed. If the `elm-make` executable can't be found in the current `PATH`, the exception `Elm::Compiler::ExecutableNotFound` will be thrown.
+> NOTE: Make sure [Elm](http://elm-lang.org/install) is installed. If the `elm-make` executable can't be found in the current `PATH` or via the `elm_make_path` option, the exception `Elm::Compiler::ExecutableNotFound` will be thrown.
 
 ```ruby
-Elm::Compiler.compile(elm_files, output_path = nil)
+Elm::Compiler.compile(elm_files, output_path: nil, elm_make_path: nil)
 ```
 
 * `elm_files`: Accepts a single file path or an array of file paths.
 * `output_path`: Path to the output file. If left blank, the compiled Javascript will be returned as a string.
+* `elm_make_path`: Path to the `elm-make` executable. If left blank, the executable will be looked up in the current `PATH`.
 
 
 
@@ -56,13 +57,13 @@ Elm::Compiler.compile(["Clock.elm", "Counter.elm"])
 Compile to file:
 
 ```ruby
-Elm::Compiler.compile("Clock.elm", "elm.js")
+Elm::Compiler.compile("Clock.elm", output_path: "elm.js")
 ```
 
 Compile multiple files to file:
 
 ```ruby
-Elm::Compiler.compile(["Clock.elm", "Counter.elm"], "elm.js")
+Elm::Compiler.compile(["Clock.elm", "Counter.elm"], output_path: "elm.js")
 ```
 
 ## Contributing

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "elm-package.json for rspec test suite",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -9,12 +9,13 @@ module Elm
       new(*args).compile
     end
 
-    def initialize(elm_files, output_path = nil)
+    def initialize(elm_files, output_path = nil, elm_path = nil)
       @elm_files = elm_files
       @output_path = output_path
+      @elm_path = elm_path
     end
 
-    attr_reader :elm_files, :output_path
+    attr_reader :elm_files, :output_path, :elm_path
 
     def compile
       fail ExecutableNotFound unless elm_executable_exists?
@@ -29,7 +30,7 @@ module Elm
     private
 
     def elm_executable_exists?
-      !find_executable0('elm-make').nil?
+      File.exist?(elm_executable)
     end
 
     def compile_to_string(elm_files)
@@ -44,8 +45,16 @@ module Elm
     end
 
     def elm_make(elm_files, output_path)
-      Open3.popen3('elm-make', *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+      Open3.popen3(elm_executable, *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
         fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
+      end
+    end
+
+    def elm_executable
+      if elm_path
+        elm_path
+      else
+        find_executable0('elm-make')
       end
     end
   end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -24,14 +24,10 @@ module Elm
       end
 
       def compile_to_string(elm_executable, elm_files)
-        output = ''
-
         Tempfile.open(['elm', '.js']) do |tempfile|
           elm_make(elm_executable, elm_files, tempfile.path)
-          output = File.read tempfile.path
+          return File.read tempfile.path
         end
-
-        output
       end
 
       def elm_make(elm_executable, elm_files, output_path)

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -1,53 +1,44 @@
 require 'elm/compiler/exceptions'
 require 'open3'
 require 'tempfile'
+require 'mkmf'
 
 module Elm
   class Compiler
-    def self.compile(*args)
-      new(*args).compile
-    end
+    class << self
+      def compile(elm_files, output_path: nil, elm_make_path: nil)
+        elm_executable = elm_make_path || find_executable0("elm-make")
+        fail ExecutableNotFound unless elm_executable_exists?(elm_executable)
 
-    def initialize(elm_files, output_path: nil, elm_make_path: nil)
-      @elm_files = elm_files
-      @output_path = output_path
-      @elm_make_path = elm_make_path
-    end
-
-    attr_reader :elm_files, :output_path, :elm_make_path
-
-    def compile
-      fail ExecutableNotFound unless elm_executable_exists?
-
-      if output_path
-        to_file
-      else
-        to_s
+        if output_path
+          elm_make(elm_executable, elm_files, output_path)
+        else
+          compile_to_string(elm_executable, elm_files)
+        end
       end
-    end
 
-    private
+      private
 
-    def elm_executable_exists?
-      File.exist?(elm_executable)
-    end
-
-    def to_s
-      Tempfile.open(['elm', '.js']) do |tempfile|
-        to_file(tempfile.path)
-        return File.read tempfile.path
+      def elm_executable_exists?(elm_executable)
+        File.executable?(elm_executable)
       end
-    end
 
-    def to_file(path = output_path)
-      # set locale to utf8 as a workaround until https://github.com/elm-lang/elm-make/pull/83 is merged and released
-      Open3.popen3({"LANG" => "en_US.UTF8" }, elm_executable, *elm_files, '--yes', '--output', path) do |_stdin, _stdout, stderr, wait_thr|
-        fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
+      def compile_to_string(elm_executable, elm_files)
+        output = ''
+
+        Tempfile.open(['elm', '.js']) do |tempfile|
+          elm_make(elm_executable, elm_files, tempfile.path)
+          output = File.read tempfile.path
+        end
+
+        output
       end
-    end
 
-    def elm_executable
-      elm_make_path || `which elm-make`.chomp
+      def elm_make(elm_executable, elm_files, output_path)
+        Open3.popen3({"LANG" => "en_US.UTF8" }, elm_executable, *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+          fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
+        end
+      end
     end
   end
 end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -5,38 +5,47 @@ require 'mkmf'
 
 module Elm
   class Compiler
-    class << self
-      def compile(elm_files, output_path = nil)
-        fail ExecutableNotFound unless elm_executable_exists?
+    def self.compile(*args)
+      new(*args).compile
+    end
 
-        if output_path
-          elm_make(elm_files, output_path)
-        else
-          compile_to_string(elm_files)
-        end
+    def initialize(elm_files, output_path = nil)
+      @elm_files = elm_files
+      @output_path = output_path
+    end
+
+    attr_reader :elm_files, :output_path
+
+    def compile
+      fail ExecutableNotFound unless elm_executable_exists?
+
+      if output_path
+        elm_make(elm_files, output_path)
+      else
+        compile_to_string(elm_files)
+      end
+    end
+
+    private
+
+    def elm_executable_exists?
+      !find_executable0('elm-make').nil?
+    end
+
+    def compile_to_string(elm_files)
+      output = ''
+
+      Tempfile.open(['elm', '.js']) do |tempfile|
+        elm_make(elm_files, tempfile.path)
+        output = File.read tempfile.path
       end
 
-      private
+      output
+    end
 
-      def elm_executable_exists?
-        !find_executable0('elm-make').nil?
-      end
-
-      def compile_to_string(elm_files)
-        output = ''
-
-        Tempfile.open(['elm', '.js']) do |tempfile|
-          elm_make(elm_files, tempfile.path)
-          output = File.read tempfile.path
-        end
-
-        output
-      end
-
-      def elm_make(elm_files, output_path)
-        Open3.popen3('elm-make', *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
-          fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
-        end
+    def elm_make(elm_files, output_path)
+      Open3.popen3('elm-make', *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+        fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
       end
     end
   end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -41,7 +41,8 @@ module Elm
     end
 
     def to_file(path = output_path)
-      Open3.popen3(elm_executable, *elm_files, '--yes', '--output', path) do |_stdin, _stdout, stderr, wait_thr|
+      # set locale to utf8 as a workaround until https://github.com/elm-lang/elm-make/pull/83 is merged and released
+      Open3.popen3({"LANG" => "en_US.UTF8" }, elm_executable, *elm_files, '--yes', '--output', path) do |_stdin, _stdout, stderr, wait_thr|
         fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
       end
     end

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -1,7 +1,6 @@
 require 'elm/compiler/exceptions'
 require 'open3'
 require 'tempfile'
-require 'mkmf'
 
 module Elm
   class Compiler
@@ -48,7 +47,7 @@ module Elm
     end
 
     def elm_executable
-      elm_make_path || find_executable0('elm-make')
+      elm_make_path || `which elm-make`.chomp
     end
   end
 end

--- a/lib/elm/compiler/version.rb
+++ b/lib/elm/compiler/version.rb
@@ -1,5 +1,5 @@
 module Elm
   class Compiler
-    VERSION = '0.1.2'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -9,7 +9,7 @@ describe Elm::Compiler do
 
   describe '#compile' do
     it "should raise ExecutableNotFound if Elm isn't installed" do
-      allow(Elm::Compiler).to receive(:elm_executable_exists?).and_return(false)
+      allow_any_instance_of(Elm::Compiler).to receive(:elm_executable_exists?).and_return(false)
       code = proc { Elm::Compiler.compile(test_file) }
       expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
     end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'mkmf'
 
 describe Elm::Compiler do
   let(:test_file) { 'spec/fixtures/Test.elm' }
@@ -54,6 +55,12 @@ describe Elm::Compiler do
       it 'should raise ExecutableNoFound if path is bad' do
         code = proc { Elm::Compiler.compile(test_file, elm_make_path: "/dev/null") }
         expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
+      end
+
+      it 'should work if path is good' do
+        output = Elm::Compiler.compile(test_file, elm_make_path: find_executable0('elm-make'))
+        expect(output).to be_instance_of(String)
+        expect(output.empty?).to be(false)
       end
     end
   end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -9,7 +9,7 @@ describe Elm::Compiler do
 
   describe '#compile' do
     it "should raise ExecutableNotFound if Elm isn't installed" do
-      allow_any_instance_of(Elm::Compiler).to receive(:elm_executable_exists?).and_return(false)
+      allow(Elm::Compiler).to receive(:elm_executable_exists?).and_return(false)
       code = proc { Elm::Compiler.compile(test_file) }
       expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
     end
@@ -52,12 +52,8 @@ describe Elm::Compiler do
 
     context 'elm_make_path given' do
       it 'should raise ExecutableNoFound if path is bad' do
-        code = proc { Elm::Compiler.compile(test_file, elm_make_path: "bad/path/to/elm-make") }
+        code = proc { Elm::Compiler.compile(test_file, elm_make_path: "/dev/null") }
         expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
-      end
-
-      it 'should work if path is good' do
-        Elm::Compiler.compile(test_file, elm_make_path: `which elm-make`.chomp)
       end
     end
   end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -49,5 +49,16 @@ describe Elm::Compiler do
         expect(File.exist?('elm.js')).to be(true)
       end
     end
+
+    context 'elm_path given' do
+      it 'should raise ExecutableNoFound if path is bad' do
+        code = proc { Elm::Compiler.compile(test_file, nil, "bad/path/to/elm") }
+        expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
+      end
+
+      it 'should work if path is good' do
+        Elm::Compiler.compile(test_file, nil, `which elm`.chomp)
+      end
+    end
   end
 end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -38,26 +38,26 @@ describe Elm::Compiler do
       end
 
       it 'should write to the given output_path' do
-        output = Elm::Compiler.compile(test_file, 'elm.js')
+        output = Elm::Compiler.compile(test_file, output_path: 'elm.js')
         expect(output).to be_nil
         expect(File.exist?('elm.js')).to be(true)
       end
 
       it 'should accept a string or an array of strings' do
-        output = Elm::Compiler.compile([test_file], 'elm.js')
+        output = Elm::Compiler.compile([test_file], output_path: 'elm.js')
         expect(output).to be_nil
         expect(File.exist?('elm.js')).to be(true)
       end
     end
 
-    context 'elm_path given' do
+    context 'elm_make_path given' do
       it 'should raise ExecutableNoFound if path is bad' do
-        code = proc { Elm::Compiler.compile(test_file, nil, "bad/path/to/elm") }
+        code = proc { Elm::Compiler.compile(test_file, elm_make_path: "bad/path/to/elm-make") }
         expect(&code).to raise_exception(Elm::Compiler::ExecutableNotFound)
       end
 
       it 'should work if path is good' do
-        Elm::Compiler.compile(test_file, nil, `which elm`.chomp)
+        Elm::Compiler.compile(test_file, elm_make_path: `which elm-make`.chomp)
       end
     end
   end

--- a/spec/fixtures/Test.elm
+++ b/spec/fixtures/Test.elm
@@ -1,3 +1,4 @@
-import Graphics.Element exposing (show)
+import Html exposing (text)
 
-main = show 3
+main =
+  text "test"


### PR DESCRIPTION
Changes the `::compile` method to accept an output_path. Based off of https://github.com/fbonetti/ruby-elm-compiler/pull/2
