### PR TITLE
Remove mkmf as a dependency

### DIFF
--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -1,37 +1,37 @@
 require 'elm/compiler/exceptions'
 require 'open3'
 require 'tempfile'
-require 'mkmf'
 
 module Elm
   class Compiler
     class << self
-      def compile(elm_files, output_path: nil, elm_make_path: nil)
-        elm_executable = elm_make_path || find_executable0("elm-make")
-        fail ExecutableNotFound unless elm_executable_exists?(elm_executable)
+      def compile(elm_files, output_path: nil, elm_make_path: "elm-make")
+        fail ExecutableNotFound unless elm_executable_exists?(elm_make_path)
 
         if output_path
-          elm_make(elm_executable, elm_files, output_path)
+          elm_make(elm_make_path, elm_files, output_path)
         else
-          compile_to_string(elm_executable, elm_files)
+          compile_to_string(elm_make_path, elm_files)
         end
       end
 
       private
 
-      def elm_executable_exists?(elm_executable)
-        File.executable?(elm_executable)
+      def elm_executable_exists?(elm_make_path)
+        Open3.popen2(elm_make_path){}.nil?
+      rescue Errno::ENOENT, Errno::EACCES
+        false
       end
 
-      def compile_to_string(elm_executable, elm_files)
+      def compile_to_string(elm_make_path, elm_files)
         Tempfile.open(['elm', '.js']) do |tempfile|
-          elm_make(elm_executable, elm_files, tempfile.path)
+          elm_make(elm_make_path, elm_files, tempfile.path)
           return File.read tempfile.path
         end
       end
 
-      def elm_make(elm_executable, elm_files, output_path)
-        Open3.popen3({"LANG" => "en_US.UTF8" }, elm_executable, *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+      def elm_make(elm_make_path, elm_files, output_path)
+        Open3.popen3({"LANG" => "en_US.UTF8" }, elm_make_path, *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
           fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
         end
       end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'mkmf'
 
 describe Elm::Compiler do
   let(:test_file) { 'spec/fixtures/Test.elm' }
@@ -58,7 +57,7 @@ describe Elm::Compiler do
       end
 
       it 'should work if path is good' do
-        output = Elm::Compiler.compile(test_file, elm_make_path: find_executable0('elm-make'))
+        output = Elm::Compiler.compile(test_file, elm_make_path: 'elm-make')
         expect(output).to be_instance_of(String)
         expect(output.empty?).to be(false)
       end


### PR DESCRIPTION
Requiring `mkmf` has some unfortunate side-effects, like polluting the top-level namespace causing naming collisions with e.g. `ffi` gem (see https://github.com/pbhogan/scrypt/issues/47). In fact, it turns out that Ruby core recommends only requiring `mkmf` in `extconf.rb`, and not anywhere else (see https://bugs.ruby-lang.org/issues/12370#note-4).

Therefore, this PR removes the `mkmf` dependency, and relies on `Open3.popenx` methods to be able to find the executables themselves via the system PATH. This also simplifies things a bit, removing the need for the `elm_executable` variable.

What do you think?
