### PR TITLE
Debug Flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
   - gem install bundler -v 1.11.2
 install:
   - bundle install
-  - npm install -g elm@0.17
+  - npm install -g elm
   - elm-package install --yes

--- a/elm-package.json
+++ b/elm-package.json
@@ -8,8 +8,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/lib/elm/compiler.rb
+++ b/lib/elm/compiler.rb
@@ -5,13 +5,13 @@ require 'tempfile'
 module Elm
   class Compiler
     class << self
-      def compile(elm_files, output_path: nil, elm_make_path: "elm-make")
+      def compile(elm_files, output_path: nil, elm_make_path: "elm-make", debug: false)
         fail ExecutableNotFound unless elm_executable_exists?(elm_make_path)
 
         if output_path
-          elm_make(elm_make_path, elm_files, output_path)
+          elm_make(elm_make_path, elm_files, output_path, debug)
         else
-          compile_to_string(elm_make_path, elm_files)
+          compile_to_string(elm_make_path, elm_files, debug)
         end
       end
 
@@ -23,15 +23,17 @@ module Elm
         false
       end
 
-      def compile_to_string(elm_make_path, elm_files)
+      def compile_to_string(elm_make_path, elm_files, debug)
         Tempfile.open(['elm', '.js']) do |tempfile|
-          elm_make(elm_make_path, elm_files, tempfile.path)
+          elm_make(elm_make_path, elm_files, tempfile.path, debug)
           return File.read tempfile.path
         end
       end
 
-      def elm_make(elm_make_path, elm_files, output_path)
-        Open3.popen3({"LANG" => "en_US.UTF8" }, elm_make_path, *elm_files, '--yes', '--output', output_path) do |_stdin, _stdout, stderr, wait_thr|
+      def elm_make(elm_make_path, elm_files, output_path, debug)
+        args = [{"LANG" => "en_US.UTF8" }, elm_make_path, *elm_files, '--yes', '--output', output_path]
+        args << "--debug" if debug
+        Open3.popen3(*args) do |_stdin, _stdout, stderr, wait_thr|
           fail CompileError, stderr.gets(nil) if wait_thr.value.exitstatus != 0
         end
       end

--- a/spec/elm/compiler_spec.rb
+++ b/spec/elm/compiler_spec.rb
@@ -62,5 +62,14 @@ describe Elm::Compiler do
         expect(output.empty?).to be(false)
       end
     end
+
+    context 'native debugger' do
+      it 'output should include native debugger functions if debug set to true' do
+        prod = Elm::Compiler.compile(test_file, elm_make_path: 'elm-make')
+        dev = Elm::Compiler.compile(test_file, elm_make_path: 'elm-make', debug: true)
+        expect(dev.length).to be > prod.length
+        expect(dev).to include('_elm_lang$virtual_dom$Native_Debug')
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'elm/compiler'
+require 'elm/compiler/version'


### PR DESCRIPTION
Adds a flag to control the elm debugger.  My use case sees me setting this to the value of `ENV["RAILS_ENV"] != "production"`, but it can be set as desired by other users.